### PR TITLE
Fixed bug where empty responses would cause React to crash

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -53,8 +53,18 @@ class App extends Component{
       var dataJSON = JSON.parse(data);
       this.setState({playerSummary: dataJSON[0].response.players[0]})
       this.setState({friendsList: dataJSON[1].friendslist.friends});
-      this.setState({recentlyPlayed: dataJSON[2].response});
-      this.setState({ownedGames: dataJSON[3].response});
+      
+      if (Object.keys(dataJSON[2].response).length === 0) {
+        this.setState({recentlyPlayed: {total_count: 0, games: []}});
+      } else {
+        this.setState({recentlyPlayed: dataJSON[2].response});
+      }
+
+      if (Object.keys(dataJSON[3].response).length === 0) {
+        this.setState({recentlyPlayed: {game_count: 0, games: []}});
+      } else {
+        this.setState({ownedGames: dataJSON[3].response});
+      }
       this.setState({gamesList: dataJSON[4].applist.apps});
 
       console.log(this.state.playerSummary);
@@ -73,6 +83,11 @@ class App extends Component{
     // Time converter function by shomrat from: https://stackoverflow.com/questions/847185/convert-a-unix-timestamp-to-time-in-javascript
     // Retrieved on 3-2-20
     function timeConverter(UNIX_timestamp){
+      if(UNIX_timestamp === 0) {
+        return '';
+      } else if (typeof UNIX_timestamp === 'undefined') {
+        return "Long, long time ago";
+      }
       var a = new Date(UNIX_timestamp * 1000);
       var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
       var year = a.getFullYear();


### PR DESCRIPTION
1. Querying a user who hasn't played in a while returns an empty object for RecentlyPlayed data. The map function when rendering recently played section was breaking React because the recentlyPlayed state was replaced with an empty object, and there was array to apply map on. Quick fix was to assign default values to state data which can possibly receive empty object.

2. Changed last log off and time created to not display anything prior to submitting. Also, after submitting, it now displays "long time ago"  instead of "undefined Nan" if last off is unknown